### PR TITLE
fix: inline function is not allowed

### DIFF
--- a/src/in-percy.d.ts
+++ b/src/in-percy.d.ts
@@ -1,1 +1,2 @@
-export = function inPercy(): boolean;
+function inPercy(): boolean;
+export = inPercy;


### PR DESCRIPTION
Fixes `Error at node_modules/@percy-io/in-percy/src/in-percy.d.ts:1:37: '{' expected.`